### PR TITLE
show returned items as well.

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -54,9 +54,9 @@ class CheckoutsController < ApplicationController
           end
         end
 
-        search.build do
-          with(:checked_in_at).equal_to nil
-        end
+        #search.build do
+        #  with(:checked_in_at).equal_to nil
+        #end
       end
 
       if current_user.try(:has_role?, 'Librarian')
@@ -92,11 +92,13 @@ class CheckoutsController < ApplicationController
         end
         search.build do
           with(:reserved).equal_to reserved
+          with(:checked_in_at).equal_to nil
         end
       end
 
       search.build do
-        order_by :created_at, :desc
+        order_by :returned, :desc
+        order_by :due_date, :desc
         facet :reserved
       end
       page = params[:page] || 1

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -42,6 +42,9 @@ class Checkout < ActiveRecord::Base
     boolean :reserved do
       reserved?
     end
+    boolean :returned do
+      checkin.nil?
+    end
   end
 
   attr_accessor :operator


### PR DESCRIPTION
This is fixes from 26th Developer workshop.
1. Changed sort criteria as 1) non-returned, 2) due_date.
2. show returned items on checkouts index. cf. next-l/enju_leaf#108
