### PR TITLE
issue #1387 : 返却処理(JSONフォーマット)で戻り値にメッセージを追加

### DIFF
--- a/app/controllers/checkins_controller.rb
+++ b/app/controllers/checkins_controller.rb
@@ -77,12 +77,12 @@ class CheckinsController < ApplicationController
         end
         flash[:message] << message if message
         format.html { redirect_to checkins_url(basket_id: @checkin.basket_id) }
-        format.json { render json: @checkin, status: :created, location: @checkin }
+        format.json { render json: {result: @checkin, messages: flash[:message]}, status: :created, location: @checkin }
         format.js { redirect_to checkins_url(basket_id: @basket.id, format: :js) }
       else
         @checkins = @basket.checkins.page(1)
         format.html { render action: "new" }
-        format.json { render json: @checkin.errors, status: :unprocessable_entity }
+        format.json { render json: {messages: @checkin.errors}, status: :unprocessable_entity }
         format.js { render action: "index" }
       end
     end

--- a/spec/controllers/checkins_controller_spec.rb
+++ b/spec/controllers/checkins_controller_spec.rb
@@ -306,6 +306,128 @@ describe CheckinsController do
     end
   end
 
+  describe 'POST create (json format)' do
+    before(:each) do
+      @attrs = { item_identifier: '00003' }
+      @invalid_attrs = { item_identifier: 'invalid' }
+      request.env["HTTP_ACCEPT"] = 'application/json'
+    end
+
+    describe 'When logged in as Administrator' do
+      login_fixture_admin
+
+      describe 'with valid params' do
+        it 'assigns a newly created checkin as @checkin' do
+          post :create, checkin: @attrs
+          assigns(:checkin).should be_nil
+        end
+
+        it 'should not create checkin without basket_id' do
+          post :create, checkin: @attrs
+          json = JSON.parse(response.body)
+          expect(json['error']).to eq('forbidden')
+        end
+
+        describe 'When basket_id is specified' do
+          it 'redirects to the created checkin' do
+            post :create, checkin: @attrs, basket_id: 9
+            expect(response).to have_http_status(:created)
+            json = JSON.parse(response.body)
+            expect(json['result']['basket_id']).to eq(9)
+            assigns(:checkin).item.circulation_status.name.should eq 'Available On Shelf'
+          end
+
+          it 'should checkin the overdue item' do
+            post :create, checkin: { item_identifier: '00014' }, basket_id: 9
+            expect(response).to have_http_status(:created)
+            assigns(:checkin).checkout.should be_valid
+            assigns(:checkin).item.circulation_status.name.should eq 'Available On Shelf'
+          end
+        end
+      end
+
+      describe 'with invalid params' do
+        it 'assigns a newly created but unsaved checkin as @checkin' do
+          post :create, checkin: @invalid_attrs
+          assigns(:checkin).should be_nil
+        end
+
+        it 'should be forbidden' do
+          post :create, checkin: @invalid_attrs
+          json = JSON.parse(response.body)
+          expect(json['error']).to eq('forbidden')
+        end
+      end
+
+      it 'should not create checkin without item_id' do
+        post :create, checkin: { item_identifier: nil }, basket_id: 9
+        assigns(:checkin).should_not be_valid
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json['messages']['base']).to match_array([I18n.t('checkin.item_not_found')])
+        expect(json['messages']['item_id']).to match_array([I18n.t('errors.messages.blank')])
+      end
+    end
+
+    describe 'When logged in as Librarian' do
+      login_fixture_librarian
+
+      describe 'with valid params' do
+        it 'assigns a newly created checkin as @checkin' do
+          post :create, checkin: @attrs
+          assigns(:checkin).should be_nil
+        end
+
+        it 'should not create checkin without basket_id' do
+          post :create, checkin: @attrs
+          json = JSON.parse(response.body)
+          expect(json['error']).to eq('forbidden')
+        end
+
+        it 'should show notification when it is reserved' do
+          post :create, checkin: { item_identifier: '00008' }, basket_id: 9
+          flash[:message].to_s.index(I18n.t('item.this_item_is_reserved')).should be_truthy
+          assigns(:checkin).item.should be_retained
+          assigns(:checkin).item.circulation_status.name.should eq 'Available On Shelf'
+          expect(response).to have_http_status(:created)
+        end
+
+        it 'should show notification when an item includes supplements' do
+          post :create, checkin: { item_identifier: '00004' }, basket_id: 9
+          assigns(:checkin).item.circulation_status.name.should eq 'Available On Shelf'
+          flash[:message].to_s.index(I18n.t('item.this_item_include_supplement')).should be_truthy
+          expect(response).to have_http_status(:created)
+        end
+      end
+
+      it "should show notice when other library's item is checked in" do
+        sign_in users(:librarian2)
+        post :create, checkin: { item_identifier: '00009' }, basket_id: 9
+        assigns(:checkin).should be_valid
+        flash[:message].to_s.index(I18n.t('checkin.other_library_item')).should be_truthy
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    describe 'When not logged in' do
+      before(:each) do
+        @attrs = { item_identifier: '00003' }
+        @invalid_attrs = { item_identifier: 'invalid' }
+      end
+
+      describe 'with valid params' do
+        it 'assigns a newly created checkin as @checkin' do
+          post :create, checkin: @attrs
+        end
+
+        it 'should redirect to new session url' do
+          post :create, checkin: @attrs
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
   describe 'PUT update' do
     before(:each) do
       @checkin = checkins(:checkin_00001)


### PR DESCRIPTION
返却処理の修正をしました。
メッセージを追加しています。ご確認いただけますでしょうか。
specは画面表示の内容をベースに対応しています。

basket の情報も返却する方が良いかと思うのでが、1.3 に対応するときにPRしたいと思っております。