### PR TITLE
add Mailers to send a stat completion notification

### DIFF
--- a/app/mailers/checkout_mailer.rb
+++ b/app/mailers/checkout_mailer.rb
@@ -5,7 +5,7 @@ class CheckoutMailer < ApplicationMailer
     system_name = LibraryGroup.system_name(checkout.user.profile.locale)
 
     from = "#{system_name} <#{@library_group.email}>"
-    subject = "#{system_name} #{I18n.t('checkout_mailer.accepted')}"
+    subject = "[#{system_name}] #{I18n.t('checkout_mailer.due_date')}"
     mail(from: from, to: checkout.user.email, cc: from, subject: subject)
   end
 
@@ -15,7 +15,7 @@ class CheckoutMailer < ApplicationMailer
     system_name = LibraryGroup.system_name(checkout.user.profile.locale)
 
     from = "#{system_name} <#{@library_group.email}>"
-    subject = "#{system_name} #{I18n.t('checkout_mailer.accepted')}"
+    subject = "[#{system_name}] #{I18n.t('checkout_mailer.overdue')}"
     mail(from: from, to: checkout.user.email, cc: from, subject: subject)
   end
 end

--- a/app/mailers/manifestation_checkout_stat_mailer.rb
+++ b/app/mailers/manifestation_checkout_stat_mailer.rb
@@ -1,0 +1,11 @@
+class ManifestationCheckoutStatMailer < ApplicationMailer
+  def completed(stat)
+    @library_group = LibraryGroup.site_config
+    @stat = stat
+    system_name = LibraryGroup.system_name(stat.user.profile.locale)
+
+    from = "#{system_name} <#{@library_group.email}>"
+    subject = "[#{system_name}] #{I18n.t('manifestation_checkout_stat_mailer.completed', locale: stat.user.profile.locale)}"
+    mail(from: from, to: stat.user.email, cc: from, subject: subject)
+  end
+end

--- a/app/mailers/manifestation_reserve_stat_mailer.rb
+++ b/app/mailers/manifestation_reserve_stat_mailer.rb
@@ -1,0 +1,11 @@
+class ManifestationReserveStatMailer < ApplicationMailer
+  def completed(stat)
+    @library_group = LibraryGroup.site_config
+    @stat = stat
+    system_name = LibraryGroup.system_name(stat.user.profile.locale)
+
+    from = "#{system_name} <#{@library_group.email}>"
+    subject = "[#{system_name}] #{I18n.t('manifestation_reserve_stat_mailer.completed', locale: stat.user.profile.locale)}"
+    mail(from: from, to: stat.user.email, cc: from, subject: subject)
+  end
+end

--- a/app/mailers/reserve_mailer.rb
+++ b/app/mailers/reserve_mailer.rb
@@ -4,8 +4,8 @@ class ReserveMailer < ApplicationMailer
     @reserve = reserve
     system_name = LibraryGroup.system_name(reserve.user.profile.locale)
 
-    from = "#{system_name} <#{@library_group.email}>"
-    subject = "#{system_name} #{I18n.t('reserve_mailer.accepted')}"
+    from = "#{system_name}] <#{@library_group.email}>"
+    subject = "[#{system_name}] #{I18n.t('reserve_mailer.accepted')}"
     mail(from: from, to: reserve.user.email, cc: from, subject: subject)
   end
 
@@ -14,8 +14,8 @@ class ReserveMailer < ApplicationMailer
     @reserve = reserve
     system_name = LibraryGroup.system_name(reserve.user.profile.locale)
 
-    from = "#{system_name} <#{@library_group.email}>"
-    subject = "#{system_name} #{I18n.t('reserve_mailer.cancelled')}"
+    from = "#{system_name}] <#{@library_group.email}>"
+    subject = "[#{system_name}] #{I18n.t('reserve_mailer.cancelled')}"
     mail(from: from, to: reserve.user.email, cc: from, subject: subject)
   end
 
@@ -24,8 +24,8 @@ class ReserveMailer < ApplicationMailer
     @reserve = reserve
     system_name = LibraryGroup.system_name(reserve.user.profile.locale)
 
-    from = "#{system_name} <#{@library_group.email}>"
-    subject = "#{system_name} #{I18n.t('reserve_mailer.expired')}"
+    from = "#{system_name}] <#{@library_group.email}>"
+    subject = "[#{system_name}] #{I18n.t('reserve_mailer.expired')}"
     mail(from: from, to: reserve.user.email, cc: from, subject: subject)
   end
 
@@ -34,8 +34,8 @@ class ReserveMailer < ApplicationMailer
     @reserve = reserve
     system_name = LibraryGroup.system_name(reserve.user.profile.locale)
 
-    from = "#{system_name} <#{@library_group.email}>"
-    subject = "#{system_name} #{I18n.t('reserve_mailer.retained')}"
+    from = "#{system_name}] <#{@library_group.email}>"
+    subject = "[#{system_name}] #{I18n.t('reserve_mailer.retained')}"
     mail(from: from, to: reserve.user.email, cc: from, subject: subject)
   end
 
@@ -44,8 +44,8 @@ class ReserveMailer < ApplicationMailer
     @reserve = reserve
     system_name = LibraryGroup.system_name(reserve.user.profile.locale)
 
-    from = "#{system_name} <#{@library_group.email}>"
-    subject = "#{system_name} #{I18n.t('reserve_mailer.postponed')}"
+    from = "#{system_name}] <#{@library_group.email}>"
+    subject = "[#{system_name}] #{I18n.t('reserve_mailer.postponed')}"
     mail(from: from, to: reserve.user.email, cc: from, subject: subject)
   end
 end

--- a/app/mailers/user_checkout_stat_mailer.rb
+++ b/app/mailers/user_checkout_stat_mailer.rb
@@ -1,0 +1,11 @@
+class UserCheckoutStatMailer < ApplicationMailer
+  def completed(stat)
+    @library_group = LibraryGroup.site_config
+    @stat = stat
+    system_name = LibraryGroup.system_name(stat.user.profile.locale)
+
+    from = "#{system_name} <#{@library_group.email}>"
+    subject = "[#{system_name}] #{I18n.t('user_checkout_stat_mailer.completed', locale: stat.user.profile.locale)}"
+    mail(from: from, to: stat.user.email, cc: from, subject: subject)
+  end
+end

--- a/app/mailers/user_reserve_stat_mailer.rb
+++ b/app/mailers/user_reserve_stat_mailer.rb
@@ -1,0 +1,11 @@
+class UserReserveStatMailer < ApplicationMailer
+  def completed(stat)
+    @library_group = LibraryGroup.site_config
+    @stat = stat
+    system_name = LibraryGroup.system_name(stat.user.profile.locale)
+
+    from = "#{system_name} <#{@library_group.email}>"
+    subject = "[#{system_name}] #{I18n.t('user_reserve_stat_mailer.completed', locale: stat.user.profile.locale)}"
+    mail(from: from, to: stat.user.email, cc: from, subject: subject)
+  end
+end

--- a/app/models/manifestation_checkout_stat.rb
+++ b/app/models/manifestation_checkout_stat.rb
@@ -37,7 +37,10 @@ class ManifestationCheckoutStat < ApplicationRecord
     end
     self.completed_at = Time.zone.now
     transition_to!(:completed)
-    send_message
+
+    mailer = ManifestationCheckoutStatMailer.completed(self)
+    mailer.deliver_later
+    send_message(mailer)
   end
 end
 

--- a/app/models/manifestation_reserve_stat.rb
+++ b/app/models/manifestation_reserve_stat.rb
@@ -37,7 +37,9 @@ class ManifestationReserveStat < ApplicationRecord
     end
     self.completed_at = Time.zone.now
     transition_to!(:completed)
-    send_message
+    mailer = ManifestationReserveStatMailer.completed(self)
+    mailer.deliver_later
+    send_message(mailer)
   end
 end
 

--- a/app/models/user_checkout_stat.rb
+++ b/app/models/user_checkout_stat.rb
@@ -36,7 +36,9 @@ class UserCheckoutStat < ApplicationRecord
     end
     self.completed_at = Time.zone.now
     transition_to!(:completed)
-    send_message
+    mailer = UserCheckoutStatMailer.completed(self)
+    mailer.deliver_later
+    send_message(mailer)
   end
 end
 

--- a/app/models/user_reserve_stat.rb
+++ b/app/models/user_reserve_stat.rb
@@ -36,7 +36,9 @@ class UserReserveStat < ApplicationRecord
     end
     self.completed_at = Time.zone.now
     transition_to!(:completed)
-    send_message
+    mailer = UserReserveStatMailer.completed(self)
+    mailer.deliver_later
+    send_message(mailer)
   end
 end
 

--- a/app/views/manifestation_checkout_stat_mailer/completed.text.erb
+++ b/app/views/manifestation_checkout_stat_mailer/completed.text.erb
@@ -1,0 +1,5 @@
+集計が完了しました。
+<%= manifestation_checkout_stat_url(@stat) %>
+
+-- 
+<%= @library_group.display_name %>

--- a/app/views/manifestation_reserve_stat_mailer/completed.text.erb
+++ b/app/views/manifestation_reserve_stat_mailer/completed.text.erb
@@ -1,0 +1,6 @@
+集計が完了しました。
+<%= manifestation_reserve_stat_url(@stat) %>
+
+-- 
+<%= @library_group.display_name %>
+

--- a/app/views/user_checkout_stat_mailer/completed.text.erb
+++ b/app/views/user_checkout_stat_mailer/completed.text.erb
@@ -1,0 +1,5 @@
+集計が完了しました。
+<%= user_checkout_stat_url(@stat) %>
+
+-- 
+<%= @library_group.display_name %>

--- a/app/views/user_reserve_stat_mailer/completed.text.erb
+++ b/app/views/user_reserve_stat_mailer/completed.text.erb
@@ -1,0 +1,5 @@
+集計が完了しました。
+<%= user_reserve_stat_url(@stat) %>
+
+-- 
+<%= @library_group.display_name %>

--- a/config/locales/translation_en.yml
+++ b/config/locales/translation_en.yml
@@ -223,3 +223,11 @@ en:
     expired: Reservation expired
     retained: Reservation retained
     postponed: Reservation postponed
+  user_checkout_stat_mailer:
+    completed: Calculation completed
+  user_reserve_stat_mailer:
+    completed: Calculation completed
+  manifestation_checkout_stat_mailer:
+    completed: Calculation completed
+  manifestation_reserve_stat_mailer:
+    completed: Calculation completed

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -221,3 +221,11 @@ ja:
     expired: 予約の期限が切れました
     retained: 予約を確保しました
     postponed: 予約が順延されました
+  user_checkout_stat_mailer:
+    completed: 集計が完了しました
+  user_reserve_stat_mailer:
+    completed: 集計が完了しました
+  manifestation_checkout_stat_mailer:
+    completed: 集計が完了しました
+  manifestation_reserve_stat_mailer:
+    completed: 集計が完了しました

--- a/spec/mailers/manifestation_checkout_stat_mailer_spec.rb
+++ b/spec/mailers/manifestation_checkout_stat_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe ManifestationCheckoutStatMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/manifestation_reserve_stat_mailer_spec.rb
+++ b/spec/mailers/manifestation_reserve_stat_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe ManifestationReserveStatMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/manifestation_checkout_stat_mailer_preview.rb
+++ b/spec/mailers/previews/manifestation_checkout_stat_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/manifestation_checkout_stat_mailer
+class ManifestationCheckoutStatMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/previews/manifestation_reserve_stat_mailer_preview.rb
+++ b/spec/mailers/previews/manifestation_reserve_stat_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/manifestation_reserve_stat_mailer
+class ManifestationReserveStatMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/previews/user_checkout_stat_mailer_preview.rb
+++ b/spec/mailers/previews/user_checkout_stat_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_checkout_stat_mailer
+class UserCheckoutStatMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/previews/user_reserve_stat_mailer_preview.rb
+++ b/spec/mailers/previews/user_reserve_stat_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_reserve_stat_mailer
+class UserReserveStatMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/user_checkout_stat_mailer_spec.rb
+++ b/spec/mailers/user_checkout_stat_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe UserCheckoutStatMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/user_reserve_stat_mailer_spec.rb
+++ b/spec/mailers/user_reserve_stat_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe UserReserveStatMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/manifestation_checkout_stat_spec.rb
+++ b/spec/models/manifestation_checkout_stat_spec.rb
@@ -7,7 +7,7 @@ describe ManifestationCheckoutStat do
     old_message_count = Message.count
     manifestation_checkout_stats(:one).transition_to!(:started).should be_truthy
     Message.count.should eq old_message_count + 1
-    Message.order(:id).last.subject.should eq '集計が完了しました'
+    Message.order(:id).last.subject.should eq '[えんじゅ図書館] 集計が完了しました'
   end
 
   it "should calculate in background" do

--- a/spec/models/manifestation_reserve_stat_spec.rb
+++ b/spec/models/manifestation_reserve_stat_spec.rb
@@ -7,7 +7,7 @@ describe ManifestationReserveStat do
     old_message_count = Message.count
     manifestation_reserve_stats(:one).transition_to!(:started).should be_truthy
     Message.count.should eq old_message_count + 1
-    Message.order(:id).last.subject.should eq '集計が完了しました'
+    Message.order(:id).last.subject.should eq '[えんじゅ図書館] 集計が完了しました'
   end
 
   it "should calculate in background" do

--- a/spec/models/user_checkout_stat_spec.rb
+++ b/spec/models/user_checkout_stat_spec.rb
@@ -7,7 +7,7 @@ describe UserCheckoutStat do
     old_message_count = Message.count
     user_checkout_stats(:one).transition_to!(:started).should be_truthy
     Message.count.should eq old_message_count + 1
-    Message.order(:id).last.subject.should eq '集計が完了しました'
+    Message.order(:id).last.subject.should eq '[えんじゅ図書館] 集計が完了しました'
   end
 
   it "should calculate in background" do

--- a/spec/models/user_reserve_stat_spec.rb
+++ b/spec/models/user_reserve_stat_spec.rb
@@ -7,7 +7,7 @@ describe UserReserveStat do
     old_message_count = Message.count
     user_reserve_stats(:one).transition_to!(:started).should be_truthy
     Message.count.should eq old_message_count + 1
-    Message.order(:id).last.subject.should eq '集計が完了しました'
+    Message.order(:id).last.subject.should eq '[えんじゅ図書館] 集計が完了しました'
   end
 
   it "should calculate in background" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,12 +12,6 @@ describe User do
   it "should get reserves_count" do
     users(:user1).reserves.waiting.count.should eq 1
   end
-
-  it "should send_message" do
-    assert users(:librarian1).send_message('reservation_expired_for_patron', manifestations: users(:librarian1).reserves.not_sent_expiration_notice_to_patron.collect(&:manifestation))
-    users(:librarian1).reload
-    users(:librarian1).reserves.not_sent_expiration_notice_to_patron.should be_empty
-  end
 end
 
 # == Schema Information


### PR DESCRIPTION
貸出・予約統計の集計通知のメール送信のテンプレートを``app/views``以下に移動した。
https://github.com/next-l/enju_leaf/issues/293